### PR TITLE
Refactor

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,6 +13,7 @@ Imports:
     httr,
     lubridate,
     purrr,
+    rlang,
     tibble
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,3 +3,4 @@
 export(az_daily)
 export(az_heat)
 export(az_hourly)
+importFrom(rlang,.data)

--- a/R/az_daily.R
+++ b/R/az_daily.R
@@ -18,6 +18,7 @@
 #'   the stations by leaving `station_id` blank and subsetting the resulting
 #'   dataframe.
 #' @return a data frame
+#' @importFrom rlang .data
 #' @export
 #'
 #' @examples
@@ -69,6 +70,6 @@ az_daily <- function(station_id = NULL, start_date = NULL, end_date = NULL) {
       c(-"meta_station_id", -"meta_station_name", -"datetime"),
       as.numeric
     )) |>
-    dplyr::mutate(datetime = lubridate::ymd(datetime))
+    dplyr::mutate(datetime = lubridate::ymd(.data$datetime))
   return(out)
 }

--- a/R/az_daily.R
+++ b/R/az_daily.R
@@ -41,40 +41,29 @@ az_daily <- function(station_id = NULL, start_date = NULL, end_date = NULL) {
 params <-
   parse_params(station_id = station_id, start = start_date, end = end_date)
 
-# Query API and wrangle output --------------------------------------------
+# Query API  --------------------------------------------
   if (length(station_id) <= 1) {
-    out <- retrieve_daily(params$station_id, params$start, params$time_interval)
+    out <-
+      retrieve_data(params$station_id,
+                    params$start,
+                    params$time_interval,
+                    endpoint = "daily")
   } else if (length(station_id) > 1) {
     out <-
       purrr::map_df(
         params$station_id,
-        function(x) retrieve_daily(x, params$start, params$time_interval)
+        function(x) {
+          retrieve_data(x, params$start, params$time_interval, endpoint = "daily")
+        }
       )
   }
+
+
+# Wrangle output ----------------------------------------------------------
   out |>
     #move metadata to beginning
     dplyr::select(starts_with("meta_"), everything()) |>
     dplyr::mutate(across(c(-meta_station_id, -meta_station_name, -datetime),
                          as.numeric)) |>
     dplyr::mutate(datetime = lubridate::ymd(datetime))
-}
-
-
-retrieve_daily <- function(station_id, start_f, time_interval) {
-  path <- c("v1", "observations", "daily", station_id, start_f, time_interval)
-  res <- httr::GET(base_url, path = path, httr::accept_json())
-  check_status(res)
-  data_raw <- httr::content(res, as = "parsed")
-  data_tidy <- data_raw$data |>
-    purrr::map_df(tibble::as_tibble)
-
-  attributes(data_tidy) <-
-    append(attributes(data_tidy), list(
-      errors = data_raw$errors,
-      i = data_raw$i,
-      l = data_raw$l,
-      s = data_raw$s,
-      t = data_raw$t
-    ))
-  data_tidy
 }

--- a/R/az_daily.R
+++ b/R/az_daily.R
@@ -57,10 +57,12 @@ az_daily <- function(station_id = NULL, start_date = NULL, end_date = NULL) {
         }
       )
   }
-
-
+ if(nrow(out) == 0) {
+   warning("No data retrieved from API.  Returning NA")
+   return(NA)
+ }
   # Wrangle output ----------------------------------------------------------
-  out |>
+  out <- out |>
     #move metadata to beginning
     dplyr::select(dplyr::starts_with("meta_"), dplyr::everything()) |>
     dplyr::mutate(dplyr::across(
@@ -68,4 +70,5 @@ az_daily <- function(station_id = NULL, start_date = NULL, end_date = NULL) {
       as.numeric
     )) |>
     dplyr::mutate(datetime = lubridate::ymd(datetime))
+  return(out)
 }

--- a/R/az_daily.R
+++ b/R/az_daily.R
@@ -38,102 +38,43 @@ az_daily <- function(station_id = NULL, start_date = NULL, end_date = NULL) {
   #TODO: check for valid station IDs
   check_internet()
 
-# Parse station IDs -------------------------------------------------------
-  if(!is.null(station_id)) {
-    if(is.numeric(station_id)) {
-      #add leading 0 if < 10
-      station_id <- formatC(station_id, flag = 0, width = 2)
-      station_id <- paste0("az", station_id)
-    }
-    # Validate station IDs
-    if(!all(grepl("^az\\d{2}$", station_id))) {
-      stop("`station_id` must be numeric or character in the format 'az01'")
-    }
-  } else {
-    station_id <- "*"
-  }
-
-
-# Check that args make sense ----------------------------------------------
-  if(!is.null(end_date) & is.null(start_date)) {
-    stop("If you supply `end_date`, you must also supply `start_date`")
-  }
-
-# Parse Dates -------------------------------------------------------------
-  if(!is.null(start_date)) {
-    #capture parsing warning and turn it into an error
-    start_date <-
-      withCallingHandlers(
-        lubridate::ymd(start_date),
-        warning = function(w) {
-          if (conditionMessage(w) == "All formats failed to parse. No formats found.") {
-            stop("`start_date` failed to parse", call. = FALSE)
-          }
-        }
-      )
-    start_f <- format(start_date, format = "%Y-%m-%dT%H:%M")
-  } else {
-    start_f <- "*" #default is today
-  }
-
-  if(!is.null(end_date)) {
-    #capture parsing warning and turn it into an error
-    end_date <-
-      withCallingHandlers(
-        lubridate::ymd(end_date),
-        warning = function(w) {
-          if (conditionMessage(w) == "All formats failed to parse. No formats found.") {
-            stop("`end_date` failed to parse", call. = FALSE)
-          }
-        }
-      )
-  } else {
-    end_date <- lubridate::today()
-  }
-
-  if ((!is.null(start_date))) {
-    if(end_date < start_date) {
-      stop("`end_date` is before `start_date`!")
-    }
-
-
-# Construct time interval for API -----------------------------------------
-    d <- lubridate::as.period(end_date - start_date)
-    time_interval <- lubridate::format_ISO8601(d)
-  } else {
-    time_interval <- "*"
-  }
-
-
-# Function to query API ---------------------------------------------------
-  retrieve_daily <- function(station_id, start_f, time_interval) {
-    path <- c("v1", "observations", "daily", station_id, start_f, time_interval)
-    res <- httr::GET(base_url, path = path, httr::accept_json())
-    check_status(res)
-    data_raw <- httr::content(res, as = "parsed")
-    data_tidy <- data_raw$data |>
-      purrr::map_df(tibble::as_tibble)
-
-    attributes(data_tidy) <-
-      append(attributes(data_tidy), list(
-        errors = data_raw$errors,
-        i = data_raw$i,
-        l = data_raw$l,
-        s = data_raw$s,
-        t = data_raw$t
-        ))
-    data_tidy
-  }
+params <-
+  parse_params(station_id = station_id, start = start_date, end = end_date)
 
 # Query API and wrangle output --------------------------------------------
-  if (length(station_id) == 1) {
-    out <- retrieve_daily(station_id, start_f, time_interval)
+  if (length(station_id) <= 1) {
+    out <- retrieve_daily(params$station_id, params$start, params$time_interval)
   } else if (length(station_id) > 1) {
-    out <- purrr::map_df(station_id, function(x) retrieve_daily(x, start_f, time_interval))
+    out <-
+      purrr::map_df(
+        params$station_id,
+        function(x) retrieve_daily(x, params$start, params$time_interval)
+      )
   }
   out |>
     #move metadata to beginning
     dplyr::select(starts_with("meta_"), everything()) |>
-    dplyr::mutate(across(c(-meta_station_id, -meta_station_name, -datetime), as.numeric)) |>
+    dplyr::mutate(across(c(-meta_station_id, -meta_station_name, -datetime),
+                         as.numeric)) |>
     dplyr::mutate(datetime = lubridate::ymd(datetime))
+}
+
+
+retrieve_daily <- function(station_id, start_f, time_interval) {
+  path <- c("v1", "observations", "daily", station_id, start_f, time_interval)
+  res <- httr::GET(base_url, path = path, httr::accept_json())
+  check_status(res)
+  data_raw <- httr::content(res, as = "parsed")
+  data_tidy <- data_raw$data |>
+    purrr::map_df(tibble::as_tibble)
+
+  attributes(data_tidy) <-
+    append(attributes(data_tidy), list(
+      errors = data_raw$errors,
+      i = data_raw$i,
+      l = data_raw$l,
+      s = data_raw$s,
+      t = data_raw$t
+    ))
+  data_tidy
 }

--- a/R/az_daily.R
+++ b/R/az_daily.R
@@ -64,7 +64,7 @@ az_daily <- function(station_id = NULL, start_date = NULL, end_date = NULL) {
     #move metadata to beginning
     dplyr::select(dplyr::starts_with("meta_"), dplyr::everything()) |>
     dplyr::mutate(dplyr::across(
-      c(-"meta_station_id",-"meta_station_name",-"datetime"),
+      c(-"meta_station_id", -"meta_station_name", -"datetime"),
       as.numeric
     )) |>
     dplyr::mutate(datetime = lubridate::ymd(datetime))

--- a/R/az_daily.R
+++ b/R/az_daily.R
@@ -38,10 +38,10 @@ az_daily <- function(station_id = NULL, start_date = NULL, end_date = NULL) {
   #TODO: check for valid station IDs
   check_internet()
 
-params <-
-  parse_params(station_id = station_id, start = start_date, end = end_date)
+  params <-
+    parse_params(station_id = station_id, start = start_date, end = end_date)
 
-# Query API  --------------------------------------------
+  # Query API  --------------------------------------------
   if (length(station_id) <= 1) {
     out <-
       retrieve_data(params$station_id,
@@ -59,11 +59,13 @@ params <-
   }
 
 
-# Wrangle output ----------------------------------------------------------
+  # Wrangle output ----------------------------------------------------------
   out |>
     #move metadata to beginning
-    dplyr::select(starts_with("meta_"), everything()) |>
-    dplyr::mutate(across(c(-meta_station_id, -meta_station_name, -datetime),
-                         as.numeric)) |>
+    dplyr::select(dplyr::starts_with("meta_"), dplyr::everything()) |>
+    dplyr::mutate(dplyr::across(
+      c(-"meta_station_id",-"meta_station_name",-"datetime"),
+      as.numeric
+    )) |>
     dplyr::mutate(datetime = lubridate::ymd(datetime))
 }

--- a/R/az_heat.R
+++ b/R/az_heat.R
@@ -59,9 +59,9 @@ az_heat <- function(station_id = NULL, start_date = NULL, end_date = NULL) {
 # Wrangle output ----------------------------------------------------------
   out |>
     #move metadata to beginning
-    dplyr::select(starts_with("meta_"), everything()) |>
-    dplyr::mutate(across(
-      c(-"meta_station_id",-"meta_station_name",-"datetime_last"),
+    dplyr::select(dplyr::starts_with("meta_"), dplyr::everything()) |>
+    dplyr::mutate(dplyr::across(
+      c(-"meta_station_id", -"meta_station_name", -"datetime_last"),
       as.numeric
     )) |>
     dplyr::mutate(datetime_last = lubridate::ymd(datetime_last))

--- a/R/az_heat.R
+++ b/R/az_heat.R
@@ -56,8 +56,13 @@ az_heat <- function(station_id = NULL, start_date = NULL, end_date = NULL) {
     )
   }
 
+  if(nrow(out) == 0) {
+    warning("No data retrieved from API.  Returning NA")
+    return(NA)
+  }
+
 # Wrangle output ----------------------------------------------------------
-  out |>
+  out <- out |>
     #move metadata to beginning
     dplyr::select(dplyr::starts_with("meta_"), dplyr::everything()) |>
     dplyr::mutate(dplyr::across(
@@ -65,4 +70,5 @@ az_heat <- function(station_id = NULL, start_date = NULL, end_date = NULL) {
       as.numeric
     )) |>
     dplyr::mutate(datetime_last = lubridate::ymd(datetime_last))
+  return(out)
 }

--- a/R/az_heat.R
+++ b/R/az_heat.R
@@ -38,102 +38,41 @@ az_heat <- function(station_id = NULL, start_date = NULL, end_date = NULL) {
   #TODO: check for valid station IDs
   check_internet()
 
-  # Parse station IDs -------------------------------------------------------
-  if(!is.null(station_id)) {
-    if(is.numeric(station_id)) {
-      #add leading 0 if < 10
-      station_id <- formatC(station_id, flag = 0, width = 2)
-      station_id <- paste0("az", station_id)
-    }
-    # Validate station IDs
-    if(!all(grepl("^az\\d{2}$", station_id))) {
-      stop("`station_id` must be numeric or character in the format 'az01'")
-    }
-  } else {
-    station_id <- "*"
-  }
-
-
-  # Check that args make sense ----------------------------------------------
-  if(!is.null(end_date) & is.null(start_date)) {
-    stop("If you supply `end_date`, you must also supply `start_date`")
-  }
-
-  # Parse Dates -------------------------------------------------------------
-  if(!is.null(start_date)) {
-    #capture parsing warning and turn it into an error
-    start_date <-
-      withCallingHandlers(
-        lubridate::ymd(start_date),
-        warning = function(w) {
-          if (conditionMessage(w) == "All formats failed to parse. No formats found.") {
-            stop("`start_date` failed to parse", call. = FALSE)
-          }
-        }
-      )
-    start_f <- format(start_date, format = "%Y-%m-%dT%H:%M")
-  } else {
-    start_f <- "*" #default is today
-  }
-
-  if(!is.null(end_date)) {
-    #capture parsing warning and turn it into an error
-    end_date <-
-      withCallingHandlers(
-        lubridate::ymd(end_date),
-        warning = function(w) {
-          if (conditionMessage(w) == "All formats failed to parse. No formats found.") {
-            stop("`end_date` failed to parse", call. = FALSE)
-          }
-        }
-      )
-  } else {
-    end_date <- lubridate::today()
-  }
-
-  if ((!is.null(start_date))) {
-    if(end_date < start_date) {
-      stop("`end_date` is before `start_date`!")
-    }
-
-
-    # Construct time interval for API -----------------------------------------
-    d <- lubridate::as.period(end_date - start_date)
-    time_interval <- lubridate::format_ISO8601(d)
-  } else {
-    time_interval <- "*"
-  }
-
-
-  # Function to query API ---------------------------------------------------
-  retrieve_heat <- function(station_id, start_f, time_interval) {
-    path <- c("v1", "observations", "hueto", station_id, start_f, time_interval)
-    res <- httr::GET(base_url, path = path, httr::accept_json())
-    check_status(res)
-    data_raw <- httr::content(res, as = "parsed")
-    data_tidy <- data_raw$data |>
-      purrr::map_df(tibble::as_tibble)
-
-    attributes(data_tidy) <-
-      append(attributes(data_tidy), list(
-        errors = data_raw$errors,
-        i = data_raw$i,
-        l = data_raw$l,
-        s = data_raw$s,
-        t = data_raw$t
-      ))
-    data_tidy
-  }
+  params <- parse_params(station_id, start = start_date, end = end_date)
 
   # Query API and wrangle output --------------------------------------------
-  if (length(station_id) == 1) {
-    out <- retrieve_heat(station_id, start_f, time_interval)
+  if (length(station_id) <= 1) {
+    out <- retrieve_heat(params$station_id, params$start, params$time_interval)
   } else if (length(station_id) > 1) {
-    out <- purrr::map_df(station_id, function(x) retrieve_heat(x, start_f, time_interval))
+    out <- purrr::map_df(
+      params$station_id,
+      function(x) retrieve_heat(x, params$start, params$time_interval)
+    )
   }
   out |>
     #move metadata to beginning
     dplyr::select(starts_with("meta_"), everything()) |>
-    dplyr::mutate(across(c(-meta_station_id, -meta_station_name, -datetime_last), as.numeric)) |>
+    dplyr::mutate(across(c(-meta_station_id, -meta_station_name, -datetime_last),
+                         as.numeric)) |>
     dplyr::mutate(datetime_last = lubridate::ymd(datetime_last))
+}
+
+
+retrieve_heat <- function(station_id, start_f, time_interval) {
+  path <- c("v1", "observations", "hueto", station_id, start_f, time_interval)
+  res <- httr::GET(base_url, path = path, httr::accept_json())
+  check_status(res)
+  data_raw <- httr::content(res, as = "parsed")
+  data_tidy <- data_raw$data |>
+    purrr::map_df(tibble::as_tibble)
+
+  attributes(data_tidy) <-
+    append(attributes(data_tidy), list(
+      errors = data_raw$errors,
+      i = data_raw$i,
+      l = data_raw$l,
+      s = data_raw$s,
+      t = data_raw$t
+    ))
+  data_tidy
 }

--- a/R/az_heat.R
+++ b/R/az_heat.R
@@ -18,6 +18,7 @@
 #'   the stations by leaving `station_id` blank and subsetting the resulting
 #'   dataframe.
 #' @return a data frame
+#' @importFrom rlang .data
 #' @export
 #'
 #' @examples
@@ -69,6 +70,6 @@ az_heat <- function(station_id = NULL, start_date = NULL, end_date = NULL) {
       c(-"meta_station_id", -"meta_station_name", -"datetime_last"),
       as.numeric
     )) |>
-    dplyr::mutate(datetime_last = lubridate::ymd(datetime_last))
+    dplyr::mutate(datetime_last = lubridate::ymd(.data$datetime_last))
   return(out)
 }

--- a/R/az_hourly.R
+++ b/R/az_hourly.R
@@ -18,6 +18,7 @@
 #'   the stations by leaving `station_id` blank and subsetting the resulting
 #'   dataframe.
 #' @return a data frame
+#' @importFrom rlang .data
 #' @export
 #'
 #' @examples
@@ -75,6 +76,6 @@ az_hourly <- function(station_id = NULL, start_date_time = NULL, end_date_time =
       ),
       as.numeric
     )) |>
-    dplyr::mutate(date_datetime = lubridate::ymd_hms(date_datetime))
+    dplyr::mutate(date_datetime = lubridate::ymd_hms(.data$date_datetime))
   return(out)
 }

--- a/R/az_hourly.R
+++ b/R/az_hourly.R
@@ -4,11 +4,11 @@
 #'   `station_id = c(8, 37)`) or as character vector with the prefix "az" and 2
 #'   digits (e.g. `station_id = c("az08", "az37")`) If left blank data for all
 #'   stations will be returned
-#' @param start_date_time character; in YYYY-MM-DD HH or another format that can be
-#'   parsed by [lubridate::ymd_h()]
-#' @param end_date_time character; in YYYY-MM-DD in YYYY-MM-DD HH or another format that
-#'   can be parsed by [lubridate::ymd_h()].  Defaults to the current time if left
-#'   blank.
+#' @param start_date_time character; in YYYY-MM-DD HH or another format that can
+#'   be parsed by [lubridate::ymd_h()]
+#' @param end_date_time character; in YYYY-MM-DD in YYYY-MM-DD HH or another
+#'   format that can be parsed by [lubridate::ymd_h()].  Defaults to the current
+#'   time if left blank.
 #' @details If neither `start_date_time` nor `end_date_time` are supplied, the
 #'   most recent day of data will be returned.  If only `start_date_time` is
 #'   supplied, then `end_date_time` defaults to the current time.  Supplying
@@ -38,11 +38,11 @@ az_hourly <- function(station_id = NULL, start_date_time = NULL, end_date_time =
   #TODO: check for valid station IDs
   check_internet()
 
-params <-
-  parse_params(station_id = station_id, start = start_date_time,
-               end = end_date_time, hour = TRUE)
+  params <-
+    parse_params(station_id = station_id, start = start_date_time,
+                 end = end_date_time, hour = TRUE)
 
-# Query API --------------------------------------------
+  # Query API --------------------------------------------
   if (length(station_id) <= 1) {
     out <-
       retrieve_data(params$station_id,
@@ -59,7 +59,7 @@ params <-
       )
   }
 
-# Wrangle output ----------------------------------------------------------
+  # Wrangle output ----------------------------------------------------------
   out |>
     #move metadata to beginning
     dplyr::select(dplyr::starts_with("meta_"), dplyr::everything()) |>

--- a/R/az_hourly.R
+++ b/R/az_hourly.R
@@ -58,9 +58,12 @@ az_hourly <- function(station_id = NULL, start_date_time = NULL, end_date_time =
         }
       )
   }
-
+  if(nrow(out) == 0) {
+    warning("No data retrieved from API.  Returning NA")
+    return(NA)
+  }
   # Wrangle output ----------------------------------------------------------
-  out |>
+  out <- out |>
     #move metadata to beginning
     dplyr::select(dplyr::starts_with("meta_"), dplyr::everything()) |>
     dplyr::mutate(dplyr::across(
@@ -73,4 +76,5 @@ az_hourly <- function(station_id = NULL, start_date_time = NULL, end_date_time =
       as.numeric
     )) |>
     dplyr::mutate(date_datetime = lubridate::ymd_hms(date_datetime))
+  return(out)
 }

--- a/R/az_hourly.R
+++ b/R/az_hourly.R
@@ -38,99 +38,53 @@ az_hourly <- function(station_id = NULL, start_date_time = NULL, end_date_time =
   #TODO: check for valid station IDs
   check_internet()
 
-# Parse station IDs -------------------------------------------------------
-  if(!is.null(station_id)) {
-    if(is.numeric(station_id)) {
-      #add leading 0 if < 10
-      station_id <- formatC(station_id, flag = 0, width = 2)
-      station_id <- paste0("az", station_id)
-    }
-    # Validate station IDs
-    if(!all(grepl("^az\\d{2}$", station_id))) {
-      stop("`station_id` must be numeric or character in the format 'az01'")
-    }
-  } else {
-    station_id <- "*"
-  }
-
-# Check that args make sense ----------------------------------------------
-  if(!is.null(end_date_time) & is.null(start_date_time)) {
-    stop("If you supply `end_date_time`, you must also supply `start_date_time`")
-  }
-
-# Parse Dates -------------------------------------------------------------
-  if(!is.null(start_date_time)) {
-    start_date_time <-
-      withCallingHandlers(
-        lubridate::ymd_h(start_date_time),
-        warning = function(w) {
-          if (conditionMessage(w) == "All formats failed to parse. No formats found.") {
-            stop("`start_date_time` failed to parse", call. = FALSE)
-          }
-        }
-      )
-
-    start_f <- format(start_date_time, format = "%Y-%m-%dT%H:%M")
-  } else {
-    start_f <- "*" #default is today
-  }
-
-  if(!is.null(end_date_time)) {
-    end_date_time <-
-      withCallingHandlers(
-        lubridate::ymd_h(end_date_time),
-        warning = function(w) {
-          if (conditionMessage(w) == "All formats failed to parse. No formats found.") {
-            stop("`end_date_time` failed to parse", call. = FALSE)
-          }
-        }
-      )
-  } else {
-    end_date_time <- lubridate::now()
-  }
-
-  if ((!is.null(start_date_time))) {
-    if(end_date_time < start_date_time) {
-      stop("`end_date_time` is before `start_date_time`!")
-    }
-
-# Construct time interval for API -----------------------------------------
-    d <- lubridate::as.period(end_date_time - start_date_time)
-    time_interval <- lubridate::format_ISO8601(d)
-  } else {
-    time_interval <- "*"
-  }
-
-# Function to query API ---------------------------------------------------
-  retrieve_hourly <- function(station_id, start_f, time_interval) {
-    path <- c("v1", "observations", "hourly", station_id, start_f, time_interval)
-    res <- httr::GET(base_url, path = path, httr::accept_json())
-    check_status(res)
-    data_raw <- httr::content(res, as = "parsed")
-    data_tidy <- data_raw$data |>
-      purrr::map_df(tibble::as_tibble)
-
-    attributes(data_tidy) <-
-      append(attributes(data_tidy), list(
-        errors = data_raw$errors,
-        i = data_raw$i,
-        l = data_raw$l,
-        s = data_raw$s,
-        t = data_raw$t
-      ))
-    data_tidy
-  }
+params <-
+  parse_params(station_id = station_id, start = start_date_time,
+               end = end_date_time, hour = TRUE)
 
 # Query API and wrangle output --------------------------------------------
-  if (length(station_id) == 1) {
-    out <- retrieve_hourly(station_id, start_f, time_interval)
+  if (length(station_id) <= 1) {
+    out <-
+      retrieve_hourly(params$station_id, params$start, params$time_interval)
   } else if (length(station_id) > 1) {
-    out <- purrr::map_df(station_id, function(x) retrieve_hourly(x, start_f, time_interval))
+    out <-
+      purrr::map_df(
+        params$station_id,
+        function(x) retrieve_hourly(x, params$start, params$time_interval)
+      )
   }
   out
   out |>
     #move metadata to beginning
     dplyr::select(dplyr::starts_with("meta_"), dplyr::everything()) |>
-    dplyr::mutate(dplyr::across(c(-"meta_station_id", -"meta_station_name", -"date_datetime", -"date_hour"), as.numeric)) |>
+    dplyr::mutate(dplyr::across(
+      c(
+        -"meta_station_id",
+        -"meta_station_name",
+        -"date_datetime",
+        -"date_hour"
+      ),
+      as.numeric
+    )) |>
     dplyr::mutate(date_datetime = lubridate::ymd_hms(date_datetime))
 }
+
+retrieve_hourly <- function(station_id, start_f, time_interval) {
+  path <- c("v1", "observations", "hourly", station_id, start_f, time_interval)
+  res <- httr::GET(base_url, path = path, httr::accept_json())
+  check_status(res)
+  data_raw <- httr::content(res, as = "parsed")
+  data_tidy <- data_raw$data |>
+    purrr::map_df(tibble::as_tibble)
+
+  attributes(data_tidy) <-
+    append(attributes(data_tidy), list(
+      errors = data_raw$errors,
+      i = data_raw$i,
+      l = data_raw$l,
+      s = data_raw$s,
+      t = data_raw$t
+    ))
+  data_tidy
+}
+

--- a/R/parse_params.R
+++ b/R/parse_params.R
@@ -1,3 +1,14 @@
+#' Parse input parameters for AZMet API
+#'
+#' @param station_id character or numeric vector
+#' @param start character; start date or date time that can be parsed by
+#'   [lubridate::ymd()] or [lubridate::ymd_h()]
+#' @param end character; end date or date time that can be parsed by
+#'   [lubridate::ymd()] or [lubridate::ymd_h()]
+#' @param hour logical; do `start` and `end` contain hours?
+#'
+#' @return a list
+#' @noRd
 parse_params <- function(station_id, start, end, hour = FALSE) {
 
   if(hour) {

--- a/R/parse_params.R
+++ b/R/parse_params.R
@@ -88,5 +88,11 @@ parse_params <- function(station_id, start, end, hour = FALSE) {
   }
 
   #return list
-  list(station_id = station_id, start = start_f, time_interval = time_interval)
+  #URLencode isn't strictly necessary, but it'll make the correct error print
+  #when a param is not properly specified instead of a generic "bad URL" error
+  list(
+    station_id = sapply(station_id, URLencode, USE.NAMES = FALSE),
+    start = URLencode(start_f),
+    time_interval = URLencode(time_interval)
+  )
 }

--- a/R/parse_params.R
+++ b/R/parse_params.R
@@ -91,8 +91,8 @@ parse_params <- function(station_id, start, end, hour = FALSE) {
   #URLencode isn't strictly necessary, but it'll make the correct error print
   #when a param is not properly specified instead of a generic "bad URL" error
   list(
-    station_id = sapply(station_id, URLencode, USE.NAMES = FALSE),
-    start = URLencode(start_f),
-    time_interval = URLencode(time_interval)
+    station_id = sapply(station_id, utils::URLencode, USE.NAMES = FALSE),
+    start = utils::URLencode(start_f),
+    time_interval = utils::URLencode(time_interval)
   )
 }

--- a/R/parse_params.R
+++ b/R/parse_params.R
@@ -1,0 +1,81 @@
+parse_params <- function(station_id, start, end, hour = FALSE) {
+
+  if(hour) {
+    parse_fun <- lubridate::ymd_h
+  } else {
+    parse_fun <- lubridate::ymd
+  }
+
+  # Parse station IDs -------------------------------------------------------
+  if(!is.null(station_id)) {
+    if(is.numeric(station_id)) {
+      #add leading 0 if < 10
+      station_id <- formatC(station_id, flag = 0, width = 2)
+      station_id <- paste0("az", station_id)
+    }
+    # Validate station IDs
+    if(!all(grepl("^az\\d{2}$", station_id))) {
+      stop("`station_id` must be numeric or character in the format 'az01'")
+    }
+  } else {
+    station_id <- "*"
+  }
+
+
+  # Check that args make sense ----------------------------------------------
+  if(!is.null(end) & is.null(start)) {
+    stop("If you supply `end_date` or `end_date_time`, you must also supply `start_date` or `start_date_time`") #TODO: maybe a method or switch() ?
+  }
+
+  # Parse Dates -------------------------------------------------------------
+  if(!is.null(start)) {
+    #capture parsing warning and turn it into an error
+    start <-
+      withCallingHandlers(
+        parse_fun(start),
+        warning = function(w) {
+          if (conditionMessage(w) == "All formats failed to parse. No formats found.") {
+            stop("`start_date` failed to parse", call. = FALSE)
+          }
+        }
+      )
+    start_f <- format(start, format = "%Y-%m-%dT%H:%M")
+  } else {
+    start_f <- "*" #default is today
+  }
+
+  if(!is.null(end)) {
+    #capture parsing warning and turn it into an error
+    end <-
+      withCallingHandlers(
+        parse_fun(end),
+        warning = function(w) {
+          if (conditionMessage(w) == "All formats failed to parse. No formats found.") {
+            stop("`end_date` failed to parse", call. = FALSE)
+          }
+        }
+      )
+  } else {
+    if (hour) {
+      end <- lubridate::now()
+    } else {
+      end <- lubridate::today()
+    }
+  }
+
+  if ((!is.null(start))) {
+    if(end < start) {
+      stop("`end_date` is before `start_date`!")
+    }
+
+
+    # Construct time interval for API -----------------------------------------
+    d <- lubridate::as.period(end - start)
+    time_interval <- lubridate::format_ISO8601(d)
+  } else {
+    time_interval <- "*"
+  }
+
+  #return list
+  list(station_id = station_id, start = start_f, time_interval = time_interval)
+}

--- a/R/retrieve_data.R
+++ b/R/retrieve_data.R
@@ -1,0 +1,18 @@
+retrieve_data <- function(station_id, start_f, time_interval, endpoint) {
+  path <- c("v1", "observations", endpoint, station_id, start_f, time_interval)
+  res <- httr::GET(base_url, path = path, httr::accept_json())
+  check_status(res)
+  data_raw <- httr::content(res, as = "parsed")
+  data_tidy <- data_raw$data |>
+    purrr::map_df(tibble::as_tibble)
+
+  attributes(data_tidy) <-
+    append(attributes(data_tidy), list(
+      errors = data_raw$errors,
+      i = data_raw$i,
+      l = data_raw$l,
+      s = data_raw$s,
+      t = data_raw$t
+    ))
+  data_tidy
+}

--- a/R/retrieve_data.R
+++ b/R/retrieve_data.R
@@ -27,4 +27,5 @@ retrieve_data <- function(station_id, start_f, time_interval,
       t = data_raw$t
     ))
   data_tidy
+  #TODO: check for 0x0 tibble and error
 }

--- a/R/retrieve_data.R
+++ b/R/retrieve_data.R
@@ -1,11 +1,11 @@
-#' Title
+#' Retrieve data from AZMet API
 #'
-#' @param station_id numeric or character vector
-#' @param start_f ISO formatted date time string
-#' @param time_interval ISO8601 formatted time interval string
-#' @param endpoint
+#' @param station_id character; in the format of "az01"
+#' @param start_f character; ISO formatted date time string
+#' @param time_interval character; ISO8601 formatted time interval string
+#' @param endpoint character; one of "daily", "hourly", or "hueto"
 #'
-#' @return
+#' @return tibble
 #' @noRd
 #'
 retrieve_data <- function(station_id, start_f, time_interval,

--- a/R/retrieve_data.R
+++ b/R/retrieve_data.R
@@ -1,4 +1,16 @@
-retrieve_data <- function(station_id, start_f, time_interval, endpoint) {
+#' Title
+#'
+#' @param station_id numeric or character vector
+#' @param start_f ISO formatted date time string
+#' @param time_interval ISO8601 formatted time interval string
+#' @param endpoint
+#'
+#' @return
+#' @noRd
+#'
+retrieve_data <- function(station_id, start_f, time_interval,
+                          endpoint = c("daily", "hourly", "hueto")) {
+  endpoint <- match.arg(endpoint)
   path <- c("v1", "observations", endpoint, station_id, start_f, time_interval)
   res <- httr::GET(base_url, path = path, httr::accept_json())
   check_status(res)

--- a/R/retrieve_data.R
+++ b/R/retrieve_data.R
@@ -18,6 +18,10 @@ retrieve_data <- function(station_id, start_f, time_interval,
   data_tidy <- data_raw$data |>
     purrr::map_df(tibble::as_tibble)
 
+  if (length(data_raw$errors) > 0) {
+    stop(paste0(data_raw$errors, "\n "))
+  }
+
   attributes(data_tidy) <-
     append(attributes(data_tidy), list(
       errors = data_raw$errors,

--- a/man/az_hourly.Rd
+++ b/man/az_hourly.Rd
@@ -12,12 +12,12 @@ az_hourly(station_id = NULL, start_date_time = NULL, end_date_time = NULL)
 digits (e.g. \code{station_id = c("az08", "az37")}) If left blank data for all
 stations will be returned}
 
-\item{start_date_time}{character; in YYYY-MM-DD HH or another format that can be
-parsed by \code{\link[lubridate:ymd_hms]{lubridate::ymd_h()}}}
+\item{start_date_time}{character; in YYYY-MM-DD HH or another format that can
+be parsed by \code{\link[lubridate:ymd_hms]{lubridate::ymd_h()}}}
 
-\item{end_date_time}{character; in YYYY-MM-DD in YYYY-MM-DD HH or another format that
-can be parsed by \code{\link[lubridate:ymd_hms]{lubridate::ymd_h()}}.  Defaults to the current time if left
-blank.}
+\item{end_date_time}{character; in YYYY-MM-DD in YYYY-MM-DD HH or another
+format that can be parsed by \code{\link[lubridate:ymd_hms]{lubridate::ymd_h()}}.  Defaults to the current
+time if left blank.}
 }
 \value{
 a data frame

--- a/tests/testthat/test-az_daily.R
+++ b/tests/testthat/test-az_daily.R
@@ -29,3 +29,5 @@ test_that("works with station_id as a vector", {
   expect_equal(unique(res$meta_station_id), c("az01", "az02"))
   expect_s3_class(az_daily(station_id = c("az01", "az02")), "data.frame")
 })
+
+#TODO: data tests (numeric? date?)

--- a/tests/testthat/test-az_daily.R
+++ b/tests/testthat/test-az_daily.R
@@ -11,43 +11,17 @@ test_that("numeric station_ids work", {
   expect_s3_class(az_daily(station_id = 12), "data.frame")
 })
 
-test_that("invalid station IDs error", {
-  skip_if_offline()
-  skip_if_not(ping_service())
-  expect_error(az_daily(station_id = 200))
-  expect_error(az_daily(station_id = "bz09"))
-  expect_error(az_daily(station_id = "az2"))
-  expect_error(az_daily(station_id = TRUE))
-  # expect_error(az_daily(station_id = 10)) #no station 10?
-})
-
 test_that("start_date works as expected", {
   skip_if_offline()
   skip_if_not(ping_service())
-  expect_s3_class(
-    az_daily(station_id = 1, start_date = "2022-09-23"),
-    "data.frame"
-    )
-  expect_s3_class(
-    az_daily(station_id = 1, start_date = "2022/09/23"),
-    "data.frame"
-    )
   start <- lubridate::now() - lubridate::weeks(1)
   expect_equal(
     az_daily(station_id = 1, start_date = format(start, "%Y-%m-%d")) |>
       nrow(),
     7
   )
-  expect_error(
-    az_daily(station_id = 1, start_date  = "last week"),
-    "`start_date` failed to parse"
-  )
 })
 
-test_that("start and end date combos error correctly", {
-  expect_error(az_daily(1, start_date = "2022-09-23", end_date = "2022-09-21"))
-  expect_error(az_daily(1, end_date = "2022-09-21"))
-})
 
 test_that("works with station_id as a vector", {
   expect_s3_class(az_daily(station_id = c(1, 2)), "data.frame")

--- a/tests/testthat/test-az_heat.R
+++ b/tests/testthat/test-az_heat.R
@@ -1,0 +1,3 @@
+test_that("multiplication works", {
+  expect_equal(2 * 2, 4)
+})

--- a/tests/testthat/test-az_hourly.R
+++ b/tests/testthat/test-az_hourly.R
@@ -14,35 +14,6 @@ test_that("all stations return data", {
   )
 })
 
-test_that("numeric station_ids work", {
-  skip_if_offline()
-  skip_if_not(ping_service())
-  expect_s3_class(
-    az_hourly(station_id = 9, start_date_time = dt, end_date_time = dt),
-    "data.frame"
-  )
-  expect_s3_class(
-    az_hourly(station_id = 12, start_date_time = dt, end_date_time = dt),
-    "data.frame"
-  )
-})
-
-test_that("invalid station IDs error", {
-  skip_if_offline()
-  skip_if_not(ping_service())
-  expect_error(
-    az_hourly(station_id = 200, start_date_time = dt, end_date_time = dt)
-  )
-  expect_error(
-    az_hourly(station_id = "bz09", start_date_time = dt, end_date_time = dt)
-  )
-  expect_error(
-    az_hourly(station_id = "az2", start_date_time = dt, end_date_time = dt)
-  )
-  expect_error(
-    az_hourly(station_id = TRUE, start_date_time = dt, end_date_time = dt)
-  )
-})
 
 test_that("start_date_time works as expected", {
   skip_if_offline()
@@ -57,18 +28,8 @@ test_that("start_date_time works as expected", {
     ) |> nrow(),
     5
   )
-  expect_error(
-    az_daily(station_id = 1, start_date  = "last week"),
-    "`start_date` failed to parse"
-  )
 })
 
-test_that("start and end date combos error correctly", {
-  expect_error(
-    az_hourly(1, start_date_time = "2022-09-23 09", end_date_time = "2022-09-23 08")
-  )
-  expect_error(az_hourly(1, end_date_time = "2022-09-21 01"))
-})
 
 test_that("works with station_id as a vector", {
   expect_s3_class(az_hourly(station_id = c(1, 2)), "data.frame")

--- a/tests/testthat/test-az_hourly.R
+++ b/tests/testthat/test-az_hourly.R
@@ -44,3 +44,5 @@ test_that("works with station_id as a vector", {
     "data.frame"
   )
 })
+
+#TODO: data tests (numeric? date?)

--- a/tests/testthat/test-parse_params.R
+++ b/tests/testthat/test-parse_params.R
@@ -1,0 +1,55 @@
+test_that("station_id gets parsed", {
+  expect_equal(parse_params(station_id = 1, start = NULL, end = NULL)$station_id, "az01")
+  expect_equal(parse_params(station_id = "az01", start = NULL, end = NULL)$station_id, "az01")
+  expect_error(parse_params(station_id = "a01", start = NULL, end = NULL))
+  expect_error(parse_params(station_id = 200, start = NULL, end = NULL))
+  expect_error(parse_params(station_id = TRUE, start = NULL, end = NULL))
+})
+
+test_that("accepts dates and date times", {
+  params_dt <-
+    parse_params(station_id = 1, start = "2022-09-09 12", end = NULL, hour = TRUE)
+  expect_type(params_dt, "list")
+  expect_equal(params_dt$start, "2022-09-09T12:00")
+
+  params_d <-
+    parse_params(station_id = 1, start = "2022-09-09", end = NULL, hour = FALSE)
+  expect_type(params_d, "list")
+  expect_equal(params_d$start, "2022-09-09T00:00")
+  expect_error(
+    parse_params(station_id = 1, start  = "last week", end = NULL),
+    "`start_date` failed to parse"
+  )
+})
+
+test_that("time_interval is correctly formed", {
+  params <-
+    parse_params(station_id = 1,
+                 start = "2022-09-09",
+                 end = "2022-09-10")
+  expect_equal(params$time_interval, "P1D")
+
+  params_dt <-
+    parse_params(
+      station_id = 1,
+      start = "2022-09-09 09",
+      end = "2022-09-10 10",
+      hour = TRUE
+    )
+  expect_equal(params_dt$time_interval, "P1DT1H")
+})
+
+test_that("start and end date combos error correctly", {
+  expect_error(
+    parse_params(1, start = "2022-09-23", end = "2022-09-22")
+  )
+  expect_error(
+    parse_params(1, start = NULL, end = "2022-09-21")
+  )
+  expect_error(
+    parse_params(1, start = "2022-09-23 09", end = "2022-09-23 08", hour = TRUE)
+  )
+  expect_error(
+    parse_params(1, start = NULL, end = "2022-09-21 01", hour = TRUE)
+  )
+})

--- a/tests/testthat/test-retrieve_data.R
+++ b/tests/testthat/test-retrieve_data.R
@@ -1,0 +1,55 @@
+test_that("bad station IDs error", {
+  expect_error(
+    retrieve_data(
+      station_id = "bz01",
+      start_f = "*",
+      time_interval = "*",
+      endpoint = "daily"
+    ),
+    "Station requested is not found."
+  )
+  expect_error(
+    retrieve_data(
+      station_id = URLencode("station one"),
+      start_f = "*",
+      time_interval = "*",
+      endpoint = "daily"
+    ),
+    "Station requested is not found."
+  )
+})
+
+test_that("bad dates error", {
+  expect_error(
+    retrieve_data(
+      station_id = "az01",
+      start_f = "now",
+      time_interval = "*",
+      endpoint = "daily"
+    ),
+    "Start date time must be in a valid date time in formatted as YYYY-MM-DDTHH:MM."
+  )
+})
+
+test_that("bad time interval errors", {
+  expect_error(
+    retrieve_data(
+      station_id = "az01",
+      start_f = "*",
+      time_interval = "a%20day",
+      endpoint = "daily"
+    )
+  )
+})
+
+test_that("multiple errors work", {
+  expect_error(
+    retrieve_data(
+      station_id = "bz01",
+      start_f = "now",
+      time_interval = "a%20day",
+      endpoint = "daily"
+    ),
+    "Collection interval must be in a valid ISO-8601 interval format: P1DT23H, where 1 is number of days and 23 is the number of hours."
+  )
+})

--- a/tests/testthat/test-retrieve_data.R
+++ b/tests/testthat/test-retrieve_data.R
@@ -10,7 +10,7 @@ test_that("bad station IDs error", {
   )
   expect_error(
     retrieve_data(
-      station_id = URLencode("station one"),
+      station_id = utils::URLencode("station one"),
       start_f = "*",
       time_interval = "*",
       endpoint = "daily"


### PR DESCRIPTION
Refactor code to repeat less.  Now there's a `parse_params()` function to parse inputs for the API, a `retrieve_data()` function to query the different API endpoints.  So now the `az_*()` functions need only call those, then wrangle the data.  Moved tests around too.