### PR TITLE
Return 0x0 tibble if no data from API

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: azmetr
 Title: Access the AZMet API
-Version: 0.0.0.9003
+Version: 0.0.0.9004
 Authors@R: 
     person("Eric", "Scott", , "ericrscott@arizona.edu", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-7430-7879"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 - functions now check if supplied `station_id` is valid and an active station before querying the API
 - added `station_info` dataset with station names, IDs, and location.
 - `az_daily()` and `az_hourly()` convert values like -999, -9999, etc. into `NA`s
+- functions now return a 0x0 tibble when no data is returned by the API
 
 # azmetr 0.0.0.9000
 

--- a/R/az_daily.R
+++ b/R/az_daily.R
@@ -17,7 +17,7 @@
 #'   the API will be made.  You may find better performance getting data for all
 #'   the stations by leaving `station_id` blank and subsetting the resulting
 #'   dataframe.
-#' @return a data frame
+#' @return a tibble
 #' @importFrom rlang .data
 #' @export
 #'
@@ -61,8 +61,9 @@ az_daily <- function(station_id = NULL, start_date = NULL, end_date = NULL) {
       )
   }
  if(nrow(out) == 0) {
-   warning("No data retrieved from API.  Returning NA")
-   return(NA)
+   warning("No data retrieved from API")
+   #return 0x0 tibble for type consistency
+   return(tibble::tibble())
  }
   # Wrangle output ----------------------------------------------------------
   out <- out |>

--- a/R/az_heat.R
+++ b/R/az_heat.R
@@ -17,7 +17,7 @@
 #'   the API will be made.  You may find better performance getting data for all
 #'   the stations by leaving `station_id` blank and subsetting the resulting
 #'   dataframe.
-#' @return a data frame
+#' @return a tibble
 #' @importFrom rlang .data
 #' @export
 #'
@@ -64,8 +64,9 @@ az_heat <- function(station_id = NULL, start_date = NULL, end_date = NULL) {
   }
 
   if(nrow(out) == 0) {
-    warning("No data retrieved from API.  Returning NA")
-    return(NA)
+    warning("No data retrieved from API")
+    #return 0x0 tibble
+    return(tibble::tibble())
   }
 
 # Wrangle output ----------------------------------------------------------

--- a/R/az_hourly.R
+++ b/R/az_hourly.R
@@ -17,7 +17,7 @@
 #'   the API will be made.  You may find better performance getting data for all
 #'   the stations by leaving `station_id` blank and subsetting the resulting
 #'   dataframe.
-#' @return a data frame
+#' @return a tibble
 #' @importFrom rlang .data
 #' @export
 #'
@@ -62,8 +62,9 @@ az_hourly <- function(station_id = NULL, start_date_time = NULL, end_date_time =
       )
   }
   if(nrow(out) == 0) {
-    warning("No data retrieved from API.  Returning NA")
-    return(NA)
+    warning("No data retrieved from API")
+    #return 0x0 tibble
+    return(tibble::tibble())
   }
   # Wrangle output ----------------------------------------------------------
   out <- out |>

--- a/man/az_daily.Rd
+++ b/man/az_daily.Rd
@@ -20,7 +20,7 @@ can be parsed by \code{\link[lubridate:ymd]{lubridate::ymd()}}.  Defaults to the
 blank.}
 }
 \value{
-a data frame
+a tibble
 }
 \description{
 Retrieve Daily Weather Data

--- a/man/az_heat.Rd
+++ b/man/az_heat.Rd
@@ -21,7 +21,7 @@ can be parsed by \code{\link[lubridate:ymd]{lubridate::ymd()}}.  Defaults to the
 blank.}
 }
 \value{
-a data frame
+a tibble
 }
 \description{
 Retrieve Accumulated Heat Units and Evapotranspiration

--- a/man/az_hourly.Rd
+++ b/man/az_hourly.Rd
@@ -20,7 +20,7 @@ format that can be parsed by \code{\link[lubridate:ymd_hms]{lubridate::ymd_h()}}
 time if left blank.}
 }
 \value{
-a data frame
+a tibble
 }
 \description{
 Retrieve Hourly Weather Data

--- a/tests/fixtures/daily_nodata.yml
+++ b/tests/fixtures/daily_nodata.yml
@@ -1,0 +1,27 @@
+http_interactions:
+- request:
+    method: get
+    uri: https://api.azmet.arizona.edu/v1/observations/daily/*/2100-01-01T00:00/P1D
+    body:
+      encoding: ''
+      string: ''
+    headers:
+      Accept: application/json
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      date: Mon, 28 Nov 2022 16:04:26 GMT
+      content-type: application/json
+      content-length: '77'
+      server: Apache/2.4.38 (Debian)
+    body:
+      encoding: UTF-8
+      file: no
+      string: |
+        {"data":[],"errors":[],"i":"P1D","l":"*","s":"2100-01-01T00:00","t":"daily"}
+  recorded_at: 2022-11-28 16:04:26 GMT
+  recorded_with: vcr/1.0.2, webmockr/0.8.2

--- a/tests/fixtures/heat_nodata.yml
+++ b/tests/fixtures/heat_nodata.yml
@@ -1,0 +1,27 @@
+http_interactions:
+- request:
+    method: get
+    uri: https://api.azmet.arizona.edu/v1/observations/hueto/*/2100-01-01T00:00/P1D
+    body:
+      encoding: ''
+      string: ''
+    headers:
+      Accept: application/json
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      date: Mon, 28 Nov 2022 16:04:27 GMT
+      content-type: application/json
+      content-length: '77'
+      server: Apache/2.4.38 (Debian)
+    body:
+      encoding: UTF-8
+      file: no
+      string: |
+        {"data":[],"errors":[],"i":"P1D","l":"*","s":"2100-01-01T00:00","t":"hueto"}
+  recorded_at: 2022-11-28 16:04:27 GMT
+  recorded_with: vcr/1.0.2, webmockr/0.8.2

--- a/tests/fixtures/hourly_nodata.yml
+++ b/tests/fixtures/hourly_nodata.yml
@@ -1,0 +1,27 @@
+http_interactions:
+- request:
+    method: get
+    uri: https://api.azmet.arizona.edu/v1/observations/hourly/*/2100-01-01T00:00/P1D
+    body:
+      encoding: ''
+      string: ''
+    headers:
+      Accept: application/json
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      date: Mon, 28 Nov 2022 16:04:29 GMT
+      content-type: application/json
+      content-length: '78'
+      server: Apache/2.4.38 (Debian)
+    body:
+      encoding: UTF-8
+      file: no
+      string: |
+        {"data":[],"errors":[],"i":"P1D","l":"*","s":"2100-01-01T00:00","t":"hourly"}
+  recorded_at: 2022-11-28 16:04:29 GMT
+  recorded_with: vcr/1.0.2, webmockr/0.8.2

--- a/tests/testthat/test-az_daily.R
+++ b/tests/testthat/test-az_daily.R
@@ -52,3 +52,14 @@ test_that("NAs converted correctly", {
   expect_true(is.na(res_missing$heat_units_13C))
   expect_true(is.na(res_missing$relative_humidity_mean))
 })
+
+test_that("no data is returned as 0x0 tibble", {
+  suppressWarnings(
+    vcr::use_cassette("daily_nodata", {
+      res_nodata <-
+        az_daily(start_date = "2100-01-01", end_date = "2100-01-02")
+    })
+  )
+  expect_true(nrow(res_nodata) == 0)
+  expect_s3_class(res_nodata, "tbl_df")
+})

--- a/tests/testthat/test-az_heat.R
+++ b/tests/testthat/test-az_heat.R
@@ -50,3 +50,12 @@ test_that("data is in correct format", {
   expect_type(res_default$eto_pen_mon_in, "double")
   expect_s3_class(res_default$datetime_last, "Date")
 })
+
+test_that("no data is returned as 0x0 tibble", {
+  vcr::use_cassette("heat_nodata", {
+    res_nodata <-
+      suppressWarnings(az_heat(start_date = "2100-01-01", end_date = "2100-01-02"))
+  })
+  expect_true(nrow(res_nodata) == 0)
+  expect_s3_class(res_nodata, "tbl_df")
+})

--- a/tests/testthat/test-az_hourly.R
+++ b/tests/testthat/test-az_hourly.R
@@ -44,3 +44,12 @@ test_that("data is in correct format", {
   expect_type(res_default$precip_total, "double")
   expect_s3_class(res_default$date_datetime, "POSIXct")
 })
+
+test_that("no data is returned as 0x0 tibble", {
+  vcr::use_cassette("hourly_nodata", {
+    res_nodata <-
+      suppressWarnings(az_hourly(start_date_time = "2100-01-01 00", end_date_time = "2100-01-02 00"))
+  })
+  expect_true(nrow(res_nodata) == 0)
+  expect_s3_class(res_nodata, "tbl_df")
+})


### PR DESCRIPTION
Changes the behavior or az_*() functions when no data is returned by the API, for example, when requesting today's data before it's up on the API.  Previously this returned `NA` and now returns a 0x0 tibble.  This change makes the type of object returned consistent (always a tibble) and makes it easier to check for no data being returned (e.g. `if(nrow(result) == 0)`)