### PR TITLE
Allow greater range of date and datetime formats

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ Imports:
     tidyselect
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.3
 URL: https://github.com/cct-datascience/azmetr
 BugReports: https://github.com/cct-datascience/azmetr/issues
 Suggests: 

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 - functions now return a 0x0 tibble when no data is returned by the API
 - changed internal use of base R pipe (`|>`) to magrittr pipe (`%>%`) instead of requiring R 4.1 or later
 - exports magrittr pipe (`%>%`) so it can be used when loading only `azmetr`
+- You can now supply POSIXct or Date values to `start_date` and `end_date` arguments in addition to character ISO representations of date (e.g. YYYY-MM-DD or YYYY/MM/DD). You can supply POSIXct to `start_date_time` and `end_date_time`.  Additionally, you can use character with at least (but potentially more) precision to the hour. (e.g., YYYY-MM-DD HH:MM:SS now works and gets rounded down to the nearest hour).
 
 # azmetr 0.0.0.9000
 

--- a/R/az_daily.R
+++ b/R/az_daily.R
@@ -7,11 +7,12 @@
 #'   `station_id = c(8, 37)`) or as character vector with the prefix "az" and 2
 #'   digits (e.g. `station_id = c("az08", "az37")`) If left blank data for all
 #'   stations will be returned
-#' @param start_date character; in YYYY-MM-DD or another format that can be
-#'   parsed by [lubridate::ymd()]
-#' @param end_date character; in YYYY-MM-DD in YYYY-MM-DD or another format that
-#'   can be parsed by [lubridate::ymd()].  Defaults to the current date if left
-#'   blank.
+#' @param start_date A length 1 vector of class Date, POSIXct, or character in
+#'   YYYY-MM-DD format.  Will be rounded **down** to the nearest day if more
+#'   precision is supplied.
+#' @param end_date A length 1 vector of class Date, POSIXct, or character in
+#'   YYYY-MM-DD format.  Will be rounded **down** to the nearest day if more
+#'   precision is supplied.  Defaults to the current date if left blank.
 #' @details If neither `start_date` nor `end_date` are supplied, the most recent
 #'   day of data will be returned.  If only `start_date` is supplied, then the
 #'   end date defaults to the current date.  Supplying only `end_date` will

--- a/R/az_heat.R
+++ b/R/az_heat.R
@@ -9,12 +9,12 @@
 #'   `station_id = c(8, 37)`) or as character vector with the prefix "az" and 2
 #'   digits (e.g. `station_id = c("az08", "az37")`) If left blank data for all
 #'   stations will be returned
-#' @param start_date character; in YYYY-MM-DD or another format that can be
-#'   parsed by [lubridate::ymd()]. Defaults to January 1st of the current year
-#'   if left blank.
-#' @param end_date character; in YYYY-MM-DD in YYYY-MM-DD or another format that
-#'   can be parsed by [lubridate::ymd()].  Defaults to the current date if left
-#'   blank.
+#' @param start_date A length 1 vector of class Date, POSIXct, or character in
+#'   YYYY-MM-DD format.  Will be rounded **down** to the nearest day if more
+#'   precision is supplied.
+#' @param end_date A length 1 vector of class Date, POSIXct, or character in
+#'   YYYY-MM-DD format.  Will be rounded **down** to the nearest day if more
+#'   precision is supplied.  Defaults to the current date if left blank.
 #' @details Unlike [az_daily()], only one row of data per station is returned,
 #'   regardless of `start_date` and `end_date`. However, the data returned is
 #'   cumulative over the time period specified by `start_date` and `end_date`.

--- a/R/az_hourly.R
+++ b/R/az_hourly.R
@@ -7,11 +7,12 @@
 #'   `station_id = c(8, 37)`) or as character vector with the prefix "az" and 2
 #'   digits (e.g. `station_id = c("az08", "az37")`) If left blank data for all
 #'   stations will be returned
-#' @param start_date_time character; in YYYY-MM-DD HH or another format that can
-#'   be parsed by [lubridate::ymd_h()]
-#' @param end_date_time character; in YYYY-MM-DD in YYYY-MM-DD HH or another
-#'   format that can be parsed by [lubridate::ymd_h()].  Defaults to the current
-#'   time if left blank.
+#' @param start_date_time A length 1 vector of class POSIXct or character in
+#'   YYYY-MM-DD HH format.  Will be rounded **down** to the nearest hour if more
+#'   precision is supplied.
+#' @param end_date_time A length 1 vector of class POSIXct or character in
+#'   YYYY-MM-DD HH format.  Will be rounded **down** to the nearest hour if more
+#'   precision is supplied.  Defaults to the current time if left blank.
 #' @details If neither `start_date_time` nor `end_date_time` are supplied, the
 #'   most recent day of data will be returned.  If only `start_date_time` is
 #'   supplied, then `end_date_time` defaults to the current time.  Supplying

--- a/R/parse_params.R
+++ b/R/parse_params.R
@@ -48,7 +48,7 @@ parse_params <- function(station_id, start, end, hour = FALSE) {
     parse_fun <- function(x) {
       lubridate::parse_date_time(x, orders = c("Ymd", "YmdHMS", "YmdHM", "YmdH")) |>
         lubridate::floor_date(unit = "day") |>
-        as_date()
+        lubridate::as_date()
     }
   }
 

--- a/man/az_daily.Rd
+++ b/man/az_daily.Rd
@@ -15,12 +15,13 @@ az_daily(station_id = NULL, start_date = NULL, end_date = NULL)
 digits (e.g. \code{station_id = c("az08", "az37")}) If left blank data for all
 stations will be returned}
 
-\item{start_date}{character; in YYYY-MM-DD or another format that can be
-parsed by \code{\link[lubridate:ymd]{lubridate::ymd()}}}
+\item{start_date}{A length 1 vector of class Date, POSIXct, or character in
+YYYY-MM-DD format.  Will be rounded \strong{down} to the nearest day if more
+precision is supplied.}
 
-\item{end_date}{character; in YYYY-MM-DD in YYYY-MM-DD or another format that
-can be parsed by \code{\link[lubridate:ymd]{lubridate::ymd()}}.  Defaults to the current date if left
-blank.}
+\item{end_date}{A length 1 vector of class Date, POSIXct, or character in
+YYYY-MM-DD format.  Will be rounded \strong{down} to the nearest day if more
+precision is supplied.  Defaults to the current date if left blank.}
 }
 \value{
 a tibble. For units and other metadata, see

--- a/man/az_heat.Rd
+++ b/man/az_heat.Rd
@@ -15,13 +15,13 @@ az_heat(station_id = NULL, start_date = NULL, end_date = NULL)
 digits (e.g. \code{station_id = c("az08", "az37")}) If left blank data for all
 stations will be returned}
 
-\item{start_date}{character; in YYYY-MM-DD or another format that can be
-parsed by \code{\link[lubridate:ymd]{lubridate::ymd()}}. Defaults to January 1st of the current year
-if left blank.}
+\item{start_date}{A length 1 vector of class Date, POSIXct, or character in
+YYYY-MM-DD format.  Will be rounded \strong{down} to the nearest day if more
+precision is supplied.}
 
-\item{end_date}{character; in YYYY-MM-DD in YYYY-MM-DD or another format that
-can be parsed by \code{\link[lubridate:ymd]{lubridate::ymd()}}.  Defaults to the current date if left
-blank.}
+\item{end_date}{A length 1 vector of class Date, POSIXct, or character in
+YYYY-MM-DD format.  Will be rounded \strong{down} to the nearest day if more
+precision is supplied.  Defaults to the current date if left blank.}
 }
 \value{
 a tibble. For units and other metadata, see

--- a/man/az_hourly.Rd
+++ b/man/az_hourly.Rd
@@ -15,12 +15,13 @@ az_hourly(station_id = NULL, start_date_time = NULL, end_date_time = NULL)
 digits (e.g. \code{station_id = c("az08", "az37")}) If left blank data for all
 stations will be returned}
 
-\item{start_date_time}{character; in YYYY-MM-DD HH or another format that can
-be parsed by \code{\link[lubridate:ymd_hms]{lubridate::ymd_h()}}}
+\item{start_date_time}{A length 1 vector of class POSIXct or character in
+YYYY-MM-DD HH format.  Will be rounded \strong{down} to the nearest hour if more
+precision is supplied.}
 
-\item{end_date_time}{character; in YYYY-MM-DD in YYYY-MM-DD HH or another
-format that can be parsed by \code{\link[lubridate:ymd_hms]{lubridate::ymd_h()}}.  Defaults to the current
-time if left blank.}
+\item{end_date_time}{A length 1 vector of class POSIXct or character in
+YYYY-MM-DD HH format.  Will be rounded \strong{down} to the nearest hour if more
+precision is supplied.  Defaults to the current time if left blank.}
 }
 \value{
 a tibble. For units and other metadata, see

--- a/tests/testthat/test-parse_params.R
+++ b/tests/testthat/test-parse_params.R
@@ -7,16 +7,67 @@ test_that("station_id gets parsed", {
   expect_error(parse_params(station_id = TRUE, start = NULL, end = NULL))
 })
 
-test_that("accepts dates and date times", {
-  params_dt <-
-    parse_params(station_id = 1, start = "2022-09-09 12", end = NULL, hour = TRUE)
-  expect_type(params_dt, "list")
-  expect_equal(params_dt$start, "2022-09-09T12:00")
+test_that("accepts dates and date times in different formats", {
+  params_dt1 <-
+    parse_params(
+      station_id = 1,
+      start = "2022-09-09 12",
+      end = NULL,
+      hour = TRUE
+    )
+  expect_type(params_dt1, "list")
+  expect_equal(params_dt1$start, "2022-09-09T12:00")
 
-  params_d <-
-    parse_params(station_id = 1, start = "2022-09-09", end = NULL, hour = FALSE)
-  expect_type(params_d, "list")
-  expect_equal(params_d$start, "2022-09-09T00:00")
+  params_dt2 <-
+    parse_params(
+      station_id = 1,
+      start = "2022-09-09 12:00",
+      end = NULL,
+      hour = TRUE
+    )
+  expect_type(params_dt2, "list")
+  expect_equal(params_dt2$start, "2022-09-09T12:00")
+
+  params_dt3 <-
+    parse_params(
+      station_id = 1,
+      start = lubridate::ymd_hm("2022-09-09 12:00"),
+      end = NULL,
+      hour = TRUE
+    )
+  expect_type(params_dt3, "list")
+  expect_equal(params_dt3$start, "2022-09-09T12:00")
+
+  params_d1 <-
+    parse_params(
+      station_id = 1,
+      start = "2022-09-09",
+      end = NULL,
+      hour = FALSE
+    )
+  expect_type(params_d1, "list")
+  expect_equal(params_d1$start, "2022-09-09T00:00")
+
+  params_d2 <-
+    parse_params(
+      station_id = 1,
+      start = "2022/09/09",
+      end = NULL,
+      hour = FALSE
+    )
+  expect_type(params_d2, "list")
+  expect_equal(params_d2$start, "2022-09-09T00:00")
+
+  params_d3 <-
+    parse_params(
+      station_id = 1,
+      start = lubridate::ymd("2022/09/09"),
+      end = NULL,
+      hour = FALSE
+    )
+  expect_type(params_d3, "list")
+  expect_equal(params_d3$start, "2022-09-09T00:00")
+
   expect_error(
     parse_params(station_id = 1, start  = "last week", end = NULL),
     "`start_date` failed to parse"


### PR DESCRIPTION
Changes all functions to use `lubridate::parse_date_time()` to parse `start` and `end` arguments internally.  This means you can now supply `az_daily()` with anything from "2022/12/25 13" to "2022-12-25 13:32:12" to a length 1 Date or POSIXct vector.  Just needs to be ISO order.  `az_hourly()` requires at least hour precision (so no Date objects allowed for that one).  Precision beyond the hour will get rounded down to the nearest hour for `az_hourly()` and precision beyond day will get rounded down to the nearest day for `az_daily()` and `az_heat()`