### PR TITLE
Memoisation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,6 +13,7 @@ Imports:
     httr,
     lubridate,
     magrittr,
+    memoise,
     purrr,
     rlang,
     tibble,

--- a/R/az_daily.R
+++ b/R/az_daily.R
@@ -55,7 +55,7 @@ az_daily <- function(station_id = NULL, start_date = NULL, end_date = NULL) {
   # Query API  --------------------------------------------
   if (length(station_id) <= 1) {
     out <-
-      retrieve_data(params$station_id,
+      retrieve_data_m(params$station_id,
                     params$start,
                     params$time_interval,
                     endpoint = "daily")
@@ -64,7 +64,7 @@ az_daily <- function(station_id = NULL, start_date = NULL, end_date = NULL) {
       purrr::map_df(
         params$station_id,
         function(x) {
-          retrieve_data(x, params$start, params$time_interval, endpoint = "daily")
+          retrieve_data_m(x, params$start, params$time_interval, endpoint = "daily")
         }
       )
   }

--- a/R/az_daily.R
+++ b/R/az_daily.R
@@ -55,7 +55,7 @@ az_daily <- function(station_id = NULL, start_date = NULL, end_date = NULL) {
   # Query API  --------------------------------------------
   if (length(station_id) <= 1) {
     out <-
-      retrieve_data_m(params$station_id,
+      retrieve_data(params$station_id,
                     params$start,
                     params$time_interval,
                     endpoint = "daily")
@@ -64,7 +64,7 @@ az_daily <- function(station_id = NULL, start_date = NULL, end_date = NULL) {
       purrr::map_df(
         params$station_id,
         function(x) {
-          retrieve_data_m(x, params$start, params$time_interval, endpoint = "daily")
+          retrieve_data(x, params$start, params$time_interval, endpoint = "daily")
         }
       )
   }

--- a/R/retrieve_data.R
+++ b/R/retrieve_data.R
@@ -33,3 +33,8 @@ retrieve_data <- function(station_id, start_f, time_interval,
   data_tidy
   #TODO: check for 0x0 tibble and error
 }
+
+
+#memoised version
+#TODO: is this going to work if the day changes over?  Like, time_interval might be "*" regardless of the actual date.
+retrieve_data_m <- memoise::memoise(retrieve_data)


### PR DESCRIPTION
### Description
<!-- describe the motivation behind the pull request and what changes it makes -->
Addresses #16 by adding memoisation to the non-exported `retrieve_data()` function.  This is done simply with the `memoise` package.  Now, if one of the API query functions is run a second time with the same inputs, it returns the cached data.

Because the caching happens at a lower level *after* input parameters are parsed for the API, the format of input doesn't matter so much.  For example:

``` r
library(tictoc)
library(azmetr)
tic()
x <- az_daily(start_date = "2023-01-01")
toc()
#> 2.455 sec elapsed

tic()
y <- az_daily(start_date = "2023/01/01")
toc()
#> 0.071 sec elapsed
```

<sup>Created on 2023-02-01 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

The cache expires after a day (or when the R session is restarted) to make sure it pulls new data from the API when it becomes available.

PR tasks:

- [x] Run `devtools::document()`
- [ ] Check that `devtools::check()` passes locally
- [ ] Update NEWS.md
