### PR TITLE
improve inst/CITATION

### DIFF
--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,27 +1,25 @@
-citHeader("To cite azmetr in publications please cite both the R package and the data source:")
+year <- ifelse("Date" %in% names(meta), sub("-.*", "", meta$Date), format(Sys.Date(), "%Y"))
 
-citEntry(
-  entry    = "Misc",
+bibentry(
+  bibtype = "manual",
+  header  = "To cite this package in publications, please use:",
   title    = "azmetr: Access Arizona weather data from the AZMet API",
   author   = c(person(given = c("Eric", "R."),
                       family = "Scott",
                       role = c("aut", "cre"),
                       email = "scottericr@gmail.com")),
-  year     = "2023",
-  version = as.package_version("0.2.0"),
+  year    = year,
+  note    = sprintf("R package version %s", meta$Version),
   url = "https://github.com/cct-datascience/azmetr",
-  doi = "10.5281/zenodo.7675685",
-  textVersion = paste(
-    'Scott ER (2023). “azmetr: Access Arizona weather data from the AZMet API. DOI:10.5281/zenodo.7675685”'
-  )
+  doi = "10.5281/zenodo.7675685"
 )
 
-citEntry(
-  entry = "Misc",
-  title = "Arizona Meteorological Network (AZMet) Data. Accessed <date accessed>",
-  author = "Arizona Meteorological Network",
-  url = "https://azmet.arizona.edu",
-  textVersion = "Arizona Meteorological Network, Arizona Meteorological Network (AZMet) Data. Accessed <date accessed>, https://azmet.arizona.edu"
+bibentry(
+  bibtype = "misc",
+  header  = "Please also cite the data source:",
+  title = "Arizona Meteorological Network (AZMet) Data",
+  author = person(family = "Arizona Meteorological Network"),
+  year    = format(Sys.Date(), "%Y"),
+  note = paste("Accessed", format(Sys.Date())),
+  url = "https://azmet.arizona.edu"
 )
-
-


### PR DESCRIPTION
Uses `bibentry()` instead of `citEntry()`, takes advantage of the `meta` object to automatically put package version and date from DESCRIPTION into citation.